### PR TITLE
Fixing Compiling with Gcc 4.9.2 on Fedora 21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from distutils.command import build_ext
 gistmodule = Extension(
 	'gist',
 	sources=['lear_gist-1.2/gist.c', 'lear_gist-1.2/standalone_image.c', 'gistmodule.c'],
-	extra_compile_args=['-DUSE_GIST', '-DSTANDALONE_GIST'],
+	extra_compile_args=['-DUSE_GIST', '-DSTANDALONE_GIST', '--std=gnu99', '-lm'],
 	include_dirs=[numpy.get_include()],
 	libraries=['fftw3f'])
 


### PR DESCRIPTION
Included Math Lib and gnu99 as standard. Things to avoid errors while the compiler look for M_PI constant and dealing with for(int i=0...) statements.
